### PR TITLE
feat: use already set config if any

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ In the [GCP docs] it is implied that you should set up one project per environme
 ### Method
 1. `cloud-functions-config` uses `process.env.GCP_PROJECT` to find out which bucket to fetch the config from.
 2. once the `config.json` file has been fetched the JSON key-values are added to `process.env` under keys prefixed with `cfc__`).
-
 ### Prerequisites
 
 - a GCS bucket named `[project-ID]-config-private` that your cloud functions has permission to read from (this should be enabled by default)
@@ -27,10 +26,11 @@ npm i cloud-functions-config
 ```javascript
 const { initConfig, getConfig } = require('cloud-functions-config')
 
+// initConfig will only requests config from GCS if none has been set yet
 initConfig()
-  .then(() => {
+  .then(config => {
       // app logic
-      console.log(getConfig())
+      console.log(config)
       // { token: 'xxxxxx', ... } 
     })
 ```

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 const { head, prop, toLower, pipe, forEachObjIndexed,
-        concat, __, map, converge, identity,
-        test, keys, filter, zipObj, replace } = require('ramda')
+        concat, __, map, converge, identity, not,
+        test, keys, filter, zipObj, replace, isEmpty } = require('ramda')
 
 const envPrefix = 'cfc__'
 
@@ -27,10 +27,15 @@ const rmPrefix = replace(envPrefix, '')
 const getEnv = () => process.env
 const getEnvVar = key => process.env[key]
 
-const getConfig = pipe(
+const getConfigKeys = pipe(
   getEnv,
   keys,
-  filter(isCFCKey),
+  filter(isCFCKey)
+)
+
+
+const getConfig = pipe(
+  getConfigKeys,
   converge(
     zipObj, [
       map(rmPrefix),
@@ -46,11 +51,24 @@ const getConfigVal = converge(
   ]
 )
 
+const isConfigInitiated = pipe(
+  getConfigKeys,
+  keys,
+  isEmpty,
+  not
+)
+
+const clearConfig = pipe(
+  getConfigKeys,
+  map(key => delete process.env[key])
+)
+
 module.exports = {
+  clearConfig,
   getBucketName,
+  isConfigInitiated,
   parseFileBuffer,
   setConfig,
   getConfig,
   getConfigVal
 }
-

--- a/config.spec.js
+++ b/config.spec.js
@@ -1,5 +1,6 @@
 const t = require('tap')
-const { getConfigVal, getConfig, setConfig, getBucketName, parseFileBuffer } = require('./config.js')
+const { getConfigVal, getConfig, setConfig, getBucketName,
+        parseFileBuffer, isConfigInitiated, clearConfig } = require('./config.js')
 
 t.test('should get bucket name according to convention', t => {
   projectName = 'test-123'
@@ -37,6 +38,22 @@ t.test('method to set and get a single env vars should work', t => {
   setConfig(config)
   const test_num = getConfigVal('test_num')
   t.equals(test_num, '123')
+  t.end()
+})
+
+t.test('should be able to tell that config has been initiated', t => {
+  clearConfig()
+  const config = {
+    key: 'set'
+  }
+  setConfig(config)
+  t.ok(isConfigInitiated())
+  t.end()
+})
+
+t.test('should be able to tell that config has NOT been initiated', t => {
+  clearConfig()
+  t.notOk(isConfigInitiated())
   t.end()
 })
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const gcs = require('@google-cloud/storage')()
-const { tap, pipe, pipeP, invoker } = require('ramda')
-const { getConfigVal, getConfig, setConfig, getBucketName, parseFileBuffer } = require('./config.js')
+const { tap, pipe, pipeP, invoker, ifElse } = require('ramda')
+const { getConfigVal, getConfig, setConfig, getBucketName, parseFileBuffer,
+        isConfigInitiated } = require('./config.js')
 
 const getFileBufferP = pipe(
   getBucketName,
@@ -14,9 +15,16 @@ const fetchConfig = pipeP(
   parseFileBuffer
 )
 
-const initConfig = pipeP(
-  fetchConfig,
-  setConfig
+const initConfig = ifElse(
+  isConfigInitiated,
+  pipe(
+    getConfig,
+    config => Promise.resolve(config)
+  ),
+  pipeP(
+    fetchConfig,
+    setConfig
+  )
 )
 
 module.exports = {


### PR DESCRIPTION
make `initConfig` resolve to already set values if such exists.
This makes it possible to call `initConfig` on every call to the cloud functions `entryPoint` but removing the need for the GCS fetch every time. 